### PR TITLE
Nix shell with Prisma engines based on package-lock.json file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if command -v nix-shell >/dev/null; then
+    use flake
+fi

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724684795,
+        "narHash": "sha256-Y0L/3OCfiD20VCgY/ZXWkijmaXGUpp1QjijZqL4aJS8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "94930d463b3c7b50eb6a6a8a25089759a8431f59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pkgs": {
+      "locked": {
+        "lastModified": 1718870667,
+        "narHash": "sha256-jab3Kpc8O1z3qxwVsCMHL4+18n5Wy/HHKyu1fcsF7gs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b10b8f00cb5494795e5f51b39210fed4d2b0748",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "prisma-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "pkgs": "pkgs"
+      },
+      "locked": {
+        "lastModified": 1719301942,
+        "narHash": "sha256-qKvcOVKoZqCfkR7Mt+7LCrsXMCNysY6JSy6QY/vXP4g=",
+        "owner": "VanCoding",
+        "repo": "nix-prisma-utils",
+        "rev": "3bf92853b6986daca112b7e07fc33f976f48ffe7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "VanCoding",
+        "repo": "nix-prisma-utils",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "prisma-utils": "prisma-utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    flake-utils.url = "github:numtide/flake-utils";
+    prisma-utils = {
+      url = "github:VanCoding/nix-prisma-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    prisma-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      prisma =
+        (prisma-utils.lib.prisma-factory {
+          nixpkgs = pkgs;
+          prisma-fmt-hash = "sha256-iOJW0KK/yWIu5VpuLrq+EC5S7n5ygu1xfiHTttYfq+A=";
+          schema-engine-hash = "sha256-RwmJu8Qm+ugpxWituK/k5DxdijJBesi82bop7ZWQ9p0=";
+          libquery-engine-hash = "sha256-P/lxd05Naf8ghTSJoIaJOMqlihhQelRwnbAPtwrAS8w=";
+          query-engine-hash = "sha256-kxhSxYFKXtIzqm0UxSu68d00n8jXj6t1Bq6X+1QAJ1E=";
+        })
+        .fromNpmLock
+        ./package-lock.json;
+    in {
+      devShell = pkgs.mkShell {
+        inherit (prisma) shellHook;
+      };
+    });
+}


### PR DESCRIPTION
These files are needed on my computer to be able to run prisma in the project without problems in common tasks like `prisma generate` which needs its own engines/utilities and cannot be retrieved from a remote server because my OS is not well supported by the library.

Fortunately there is a "flake" from the Nix community that solved this problem for me.

Note: I will need to update the hashes every time the library version is updated and then the hashes in the package-lock.json file are modified.