### PR TITLE
Only retrieve Prometeo providers that contains "corp" or "smes" in their codes

### DIFF
--- a/services/prometeo/prometeo.service.ts
+++ b/services/prometeo/prometeo.service.ts
@@ -114,7 +114,12 @@ export class PrometeoService {
 
     const results = await Promise.allSettled(
       providers
-        .filter((p) => p.country === countryCode)
+        .filter((p) => {
+          const isSpecifiedCountry = p.country === countryCode;
+          const isCorp = p.code.includes("corp") || p.code.includes("smes");
+
+          return isSpecifiedCountry && isCorp;
+        })
         .map(async (p) => await getProviderDetails(p.code)),
     );
 


### PR DESCRIPTION
## 🎟️ Tracking

Closes [QPA-43](https://qompa.atlassian.net/browse/QPA-43) and [QPA-41](https://qompa.atlassian.net/browse/QPA-41)

## 📔 Objective

Integrate endpoint to retrieve Prometeo's providers (data sources).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- --Used internationalization (i18n) for all UI strings--
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team


[QPA-43]: https://qompa.atlassian.net/browse/QPA-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QPA-41]: https://qompa.atlassian.net/browse/QPA-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ