### PR TITLE
QPA-38: Endpoint to list user accounts from Prometeo API

### DIFF
--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -1,5 +1,6 @@
 import { api, type Header } from "encore.dev/api";
 
+import type { PrometeoAPILoginRequestBody } from "./types/prometeo-api";
 import applicationContext from "../applicationContext";
 import type { Supplier } from "./types/supplier";
 
@@ -20,11 +21,7 @@ export const getSuppliers = api(
 // ! restrict access to internal level
 export const login = api(
   { expose: true, method: "POST", path: "/third-party/prometeo/login" },
-  async (payload: {
-    provider: string;
-    username: string;
-    password: string;
-  }): Promise<{ key: string }> => {
+  async (payload: PrometeoAPILoginRequestBody): Promise<{ key: string }> => {
     const { prometeoService } = await applicationContext;
 
     const { key } = await prometeoService.login(payload);

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -1,7 +1,10 @@
-import { api } from "encore.dev/api";
+import { api, type Header } from "encore.dev/api";
 
 import applicationContext from "../applicationContext";
 import type { Supplier } from "./types/supplier";
+
+// If for any reason, the client will store the Prometeo API's session key,
+// the header to pass it is "X-Prometeo-Session-Key"
 
 export const getSuppliers = api(
   { expose: true, method: "GET", path: "/third-party/prometeo/suppliers" },
@@ -27,5 +30,19 @@ export const login = api(
     const { key } = await prometeoService.login(payload);
 
     return { key };
+  },
+);
+
+// ! restrict access to internal level
+export const logout = api(
+  { expose: true, method: "POST", path: "/third-party/prometeo/logout" },
+  async (payload: { key: Header<"X-Prometeo-Session-Key"> }): Promise<{
+    success: boolean;
+  }> => {
+    const { prometeoService } = await applicationContext;
+
+    const { success } = await prometeoService.logout(payload.key);
+
+    return { success };
   },
 );

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -1,6 +1,7 @@
 import { api, type Header } from "encore.dev/api";
 
 import type { PrometeoAPILoginRequestBody } from "./types/prometeo-api";
+import type { UserBankAccount } from "./types/user-account";
 import applicationContext from "../applicationContext";
 import type { Supplier } from "./types/supplier";
 
@@ -41,5 +42,18 @@ export const logout = api(
     const { success } = await prometeoService.logout(payload.key);
 
     return { success };
+  },
+);
+
+export const listUserAccounts = api(
+  { expose: true, method: "GET", path: "/third-party/prometeo/accounts" },
+  async (payload: { key: Header<"X-Prometeo-Session-Key"> }): Promise<{
+    data: UserBankAccount[];
+  }> => {
+    const { prometeoService } = await applicationContext;
+
+    const data = await prometeoService.listUserAccounts(payload.key);
+
+    return { data };
   },
 );

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -1,3 +1,5 @@
+import type { UserBankAccount } from "./user-account";
+
 export interface PrometeoAPILoginRequestBody {
   provider: string;
   username: string;
@@ -9,6 +11,11 @@ export interface PrometeoAPILoginRequestBody {
 export interface PrometeoAPIErrorLoginResponse {
   status: "error";
   message: string;
+}
+
+export interface PrometeoAPIErrorInvalidKeyResponse {
+  status: "error";
+  message: "Invalid key";
 }
 
 export interface PrometeoAPIIncompleteLoginResponse {
@@ -33,3 +40,12 @@ export interface PrometeoAPISuccessfulLogoutResponse {
 export type PrometeoAPILogoutResponse =
   | PrometeoAPISuccessfulLogoutResponse
   | PrometeoAPIErrorLoginResponse;
+
+export interface PrometeoAPISuccessfulListUserAccountsResponse {
+  status: "success";
+  accounts: UserBankAccount[];
+}
+
+export type PrometeoAPIListUserAccountsResponse =
+  | PrometeoAPISuccessfulListUserAccountsResponse
+  | PrometeoAPIErrorInvalidKeyResponse;

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -3,11 +3,17 @@ export interface PrometeoAPILoginRequestBody {
   username: string;
   password: string;
   type?: string;
+  otp?: string;
 }
 
 export interface PrometeoAPIErrorLoginResponse {
   status: "error";
   message: string;
+}
+
+export interface PrometeoAPIIncompleteLoginResponse {
+  status: "interaction_required";
+  context: string;
 }
 
 export interface PrometeoAPISuccessfulLoginResponse {
@@ -17,6 +23,7 @@ export interface PrometeoAPISuccessfulLoginResponse {
 
 export type PrometeoAPILoginResponse =
   | PrometeoAPISuccessfulLoginResponse
+  | PrometeoAPIIncompleteLoginResponse
   | PrometeoAPIErrorLoginResponse;
 
 export interface PrometeoAPISuccessfulLogoutResponse {

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -5,16 +5,24 @@ export interface PrometeoAPILoginRequestBody {
   type?: string;
 }
 
-export interface PrometeoAPISuccessfulLoginResponse {
-  status: "logged_in";
-  key: string;
-}
-
 export interface PrometeoAPIErrorLoginResponse {
   status: "error";
   message: string;
 }
 
+export interface PrometeoAPISuccessfulLoginResponse {
+  status: "logged_in";
+  key: string;
+}
+
 export type PrometeoAPILoginResponse =
   | PrometeoAPISuccessfulLoginResponse
+  | PrometeoAPIErrorLoginResponse;
+
+export interface PrometeoAPISuccessfulLogoutResponse {
+  status: "logged_out";
+}
+
+export type PrometeoAPILogoutResponse =
+  | PrometeoAPISuccessfulLogoutResponse
   | PrometeoAPIErrorLoginResponse;

--- a/services/prometeo/types/user-account.ts
+++ b/services/prometeo/types/user-account.ts
@@ -1,0 +1,8 @@
+export interface UserBankAccount {
+  id: string;
+  name: string;
+  number: string;
+  branch: string;
+  currency: string;
+  balance: number;
+}


### PR DESCRIPTION
## 🎟️ Tracking

Closes [QPA-38](https://qompa.atlassian.net/browse/QPA-38)

## 📔 Objective

Implement endpoint to list user accounts from Prometeo API following [this recipe](https://docs.prometeoapi.com/recipes/transferencias).

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/d597f65b-3704-401b-a1b0-cddbf3c32d3d)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- --Used internationalization (i18n) for all UI strings--
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[QPA-38]: https://qompa.atlassian.net/browse/QPA-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ