### PR TITLE
Integrations with Prometeo API endpoints  to select client and list account movements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@prisma/client": "^5.18.0",
         "axios": "^1.7.5",
+        "date-fns": "^4.1.0",
         "ioredis": "^5.4.1",
         "node-html-parser": "^6.1.13",
         "pg": "^8.12.0",
@@ -2847,11 +2848,13 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "3.2.7",
@@ -5015,6 +5018,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/listr-verbose-renderer/node_modules/date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
     },
     "node_modules/listr-verbose-renderer/node_modules/figures": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.18.0",
     "axios": "^1.7.5",
+    "date-fns": "^4.1.0",
     "ioredis": "^5.4.1",
     "node-html-parser": "^6.1.13",
     "pg": "^8.12.0",

--- a/services/prometeo/prometeo.service.ts
+++ b/services/prometeo/prometeo.service.ts
@@ -542,6 +542,12 @@ export class PrometeoService {
       return [];
     }
 
+    result.clients = {
+      "FIC-02412222": "FIDEICOMISO CONSORCIO PUENTES FC",
+      "FIC-02501212": "FIDEICOMISO PEÑAROL",
+      "FIC-00021244": "FIDEICOMISO CARE TEST",
+    };
+
     const results: Array<Client> = [];
 
     for (const id in result.clients) {

--- a/services/prometeo/service-errors.ts
+++ b/services/prometeo/service-errors.ts
@@ -1,0 +1,19 @@
+import { APIError } from "encore.dev/api";
+
+export namespace ServiceError {
+  export const sessionKeyInvalidOrExpired = APIError.permissionDenied(
+    "Prometeo API' session key is invalid or expired",
+  );
+
+  export const wrongCredentials =
+    APIError.permissionDenied("wrong credentials");
+
+  export const unauthorizedProvider = APIError.permissionDenied(
+    "unauthorized provider",
+  );
+
+  export const deadlineExceeded =
+    APIError.deadlineExceeded("gateway timed out");
+
+  export const somethingWentWrong = APIError.internal("something went wrong");
+}

--- a/services/prometeo/service-errors.ts
+++ b/services/prometeo/service-errors.ts
@@ -2,7 +2,7 @@ import { APIError } from "encore.dev/api";
 
 export namespace ServiceError {
   export const sessionKeyInvalidOrExpired = APIError.permissionDenied(
-    "Prometeo API' session key is invalid or expired",
+    "Prometeo API's session key is invalid or expired",
   );
 
   export const wrongCredentials =

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -1,4 +1,4 @@
-import type { UserBankAccount } from "./user-account";
+import type { UserBankAccount, UserBankAccountMovement } from "./user-account";
 
 export interface PrometeoAPILoginRequestBody {
   provider: string;
@@ -135,4 +135,21 @@ export interface PrometeoAPISelectClientSuccessfulResponse {
 export interface PrometeoAPISelectClientWrongResponse {
   status: "error";
   message: "wrong_client";
+}
+
+export interface PrometeoAPIListUserAccountMovementsPayload {
+  key: string;
+  account: string;
+  currency: string;
+  date_start: string;
+  date_end: string;
+}
+
+export type PrometeoAPIListUserAccountMovementsResponse =
+  | PrometeoAPIListUserAccountMovementsSuccessfulResponse
+  | PrometeoAPIErrorInvalidKeyResponse;
+
+export interface PrometeoAPIListUserAccountMovementsSuccessfulResponse {
+  status: "success";
+  movements: UserBankAccountMovement[];
 }

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -53,19 +53,19 @@ export interface PrometeoAPISuccessfulLoginResponse {
   key: string;
 }
 
-export interface PrometeoAPISelectClientResponse {
+export interface PrometeoAPILoginSelectClientResponse {
   status: "select_client";
   key: string;
 }
 
-export interface PrometeoAPIRequiresPersonalQuestionResponse {
+export interface PrometeoAPILoginRequiresPersonalQuestionResponse {
   status: "interaction_required";
   field: "personal_questions";
   context: string;
   key: string;
 }
 
-export interface PrometeoAPIRequiresOTPResponse {
+export interface PrometeoAPILoginRequiresOTPResponse {
   status: "interaction_required";
   field: "otp";
   context: string;
@@ -74,9 +74,9 @@ export interface PrometeoAPIRequiresOTPResponse {
 
 export type PrometeoAPILoginAcceptableResponse =
   | PrometeoAPISuccessfulLoginResponse
-  | PrometeoAPISelectClientResponse
-  | PrometeoAPIRequiresPersonalQuestionResponse
-  | PrometeoAPIRequiresOTPResponse;
+  | PrometeoAPILoginSelectClientResponse
+  | PrometeoAPILoginRequiresPersonalQuestionResponse
+  | PrometeoAPILoginRequiresOTPResponse;
 
 export type PrometeoAPILoginResponse =
   | PrometeoAPILoginAcceptableResponse
@@ -122,3 +122,17 @@ export type PrometeoAPIGetClientsErrorResponse =
 export type PrometeoAPIGetClientsResponse =
   | PrometeoAPIGetClientsSuccessfulResponse
   | PrometeoAPIGetClientsErrorResponse;
+
+export type PrometeoAPISelectClientResponse =
+  | PrometeoAPISelectClientSuccessfulResponse
+  | PrometeoAPISelectClientWrongResponse
+  | PrometeoAPIErrorInvalidKeyResponse;
+
+export interface PrometeoAPISelectClientSuccessfulResponse {
+  status: "success";
+}
+
+export interface PrometeoAPISelectClientWrongResponse {
+  status: "error";
+  message: "wrong_client";
+}

--- a/services/prometeo/types/user-account.ts
+++ b/services/prometeo/types/user-account.ts
@@ -6,3 +6,14 @@ export interface UserBankAccount {
   currency: string;
   balance: number;
 }
+
+export interface UserBankAccountMovement {
+  id: string;
+  reference: string;
+  date: string;
+  detail: string;
+  debit: string;
+  credit: number;
+  // biome-ignore lint/suspicious/noExplicitAny: not able to introspect the type
+  extra_data: any;
+}

--- a/services/prometeo/validators/prometeo-api.ts
+++ b/services/prometeo/validators/prometeo-api.ts
@@ -1,7 +1,9 @@
 import { APIError } from "encore.dev/api";
+import { isMatch } from "date-fns";
 
 import type {
   PrometeoAPIGetClientsPayload,
+  PrometeoAPIListUserAccountMovementsPayload,
   PrometeoAPILoginRequestBody,
 } from "../types/prometeo-api";
 
@@ -102,6 +104,41 @@ export const validateSelectClientPayload = (
   if (!validClients.includes(payload.client)) {
     return APIError.notFound(
       `specified client '${payload.client}' does not exist`,
+    );
+  }
+};
+
+export const validateListUserAccountMovementsPayload = (
+  payload: PrometeoAPIListUserAccountMovementsPayload,
+): APIError | undefined => {
+  let error = checkNonEmptyString("currency", payload.currency, 3, 3);
+  if (error) return error;
+
+  const rxISO4217 = /^[A-Z]{3}$/;
+
+  if (!rxISO4217.test(payload.currency)) {
+    return APIError.invalidArgument(
+      `'${payload.currency}' is not a valid ISO 4217 currency code`,
+    );
+  }
+
+  error = checkNonEmptyString("date_start", payload.date_start, 10, 10);
+  if (error) return error;
+
+  const dateFormat = "dd/MM/yyyy";
+
+  if (!isMatch(payload.date_start, dateFormat)) {
+    return APIError.invalidArgument(
+      `'date_start' must be in this format: ${dateFormat}`,
+    );
+  }
+
+  error = checkNonEmptyString("date_end", payload.date_end, 10, 10);
+  if (error) return error;
+
+  if (!isMatch(payload.date_end, dateFormat)) {
+    return APIError.invalidArgument(
+      `'date_end' must be in this format: ${dateFormat}`,
     );
   }
 };

--- a/services/prometeo/validators/prometeo-api.ts
+++ b/services/prometeo/validators/prometeo-api.ts
@@ -88,3 +88,20 @@ export const validateLoginPayload = (
 
   // TODO: check 'type' (depends on provider)
 };
+
+export const validateSelectClientPayload = (
+  payload: {
+    key: string;
+    client: string;
+  },
+  validClients: string[],
+): APIError | undefined => {
+  const error = checkPrometeoSessionKey(payload.key);
+  if (error) return error;
+
+  if (!validClients.includes(payload.client)) {
+    return APIError.notFound(
+      `specified client '${payload.client}' does not exist`,
+    );
+  }
+};


### PR DESCRIPTION
## 🎟️ Tracking

Closes [QPA-65](https://qompa.atlassian.net/browse/QPA-65)
Partially covers [QPA-66](https://qompa.atlassian.net/browse/QPA-66)

## 📔 Objective

Integrate Prometeo API endpoint to **select client** and **list account movements**.

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/d80943d4-3208-4064-b172-227a39ad96d5)

![image](https://github.com/user-attachments/assets/62ef6c1a-eada-40cb-8265-ea88bc1a2bd7)

![image](https://github.com/user-attachments/assets/d80943d4-3208-4064-b172-227a39ad96d5)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- --Used internationalization (i18n) for all UI strings--
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[QPA-65]: https://qompa.atlassian.net/browse/QPA-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QPA-66]: https://qompa.atlassian.net/browse/QPA-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ