### PR TITLE
QPA-66: Get balances from a given account

### DIFF
--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -192,7 +192,11 @@ export const selectClient = api(
     key: Header<"X-Prometeo-Session-Key">;
     // The ID of the client to use for the current session.
     client: string;
-  }): Promise<void> => {
+  }): Promise<{
+    // The session key to be passed to the Prometeo API. This key
+    // might change in certain providers so the previous is invalidated.
+    key: string;
+  }> => {
     const { prometeoService } = await applicationContext;
 
     const clients = await prometeoService.getClients({ key: payload.key });
@@ -211,6 +215,11 @@ export const selectClient = api(
       throw apiError;
     }
 
-    await prometeoService.selectClient(payload.key, payload.client);
+    const result = await prometeoService.selectClient(
+      payload.key,
+      payload.client,
+    );
+
+    return result;
   },
 );

--- a/services/prometeo/prometeo.service.ts
+++ b/services/prometeo/prometeo.service.ts
@@ -619,11 +619,15 @@ export class PrometeoService {
     key: string,
     client: string,
     config?: Partial<PrometeoRequestConfig>,
-  ): Promise<void> {
+  ): Promise<{ key: string }> {
     try {
       const result = await this.doSelectClient(key, client, config);
       if (result.status === "success") {
-        return;
+        return {
+          // If the request returns a new key that is passed, otherwise
+          // the same key used to perform the request is returned.
+          key: result.key ?? key,
+        };
       }
 
       if (result.message === "Invalid key") {
@@ -633,6 +637,10 @@ export class PrometeoService {
       if (result.message === "wrong_client") {
         throw APIError.notFound(`specified client '${client}' does not exist`);
       }
+
+      log.error("something is off with the Prometeo API .:", result);
+
+      throw ServiceError.somethingWentWrong;
     } catch (error) {
       if (error instanceof APIError) throw error;
 

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -135,6 +135,11 @@ export type PrometeoAPISelectClientResponse =
 
 export interface PrometeoAPISelectClientSuccessfulResponse {
   status: "success";
+  // This key is only present in certian providers. It should
+  // be returned to the client to use for future requests, otherwise
+  // the client can keep using the same session key that used to perform
+  // the request.
+  key?: string;
 }
 
 export interface PrometeoAPISelectClientWrongResponse {

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -1,10 +1,15 @@
 import type { UserBankAccount, UserBankAccountMovement } from "./user-account";
 
 export interface PrometeoAPILoginRequestBody {
+  // The provider to login to.
   provider: string;
+  // The "access key ID" to use for the login.
   username: string;
+  // The "access key secret" to use for the login.
   password: string;
+  // Optional. The type of account or document (this will vary depending on the provider).
   type?: string;
+  // Optional. The OTP code to use for the login if the provider required it in a previous call.
   otp?: string;
 }
 


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR depends on https://github.com/Qompa-Fi/encore-nestjs-backend/pull/54.

## 🎟️ Tracking

[QPA-66](https://qompa.atlassian.net/browse/QPA-66)

## 📔 Objective

Retrieve balances from a given account(covered here https://github.com/Qompa-Fi/encore-nestjs-backend/pull/53)

### So, what's new?

The endpoint to select a client returns the **session key** to be used after that call in the response body.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- --Used internationalization (i18n) for all UI strings--
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[QPA-66]: https://qompa.atlassian.net/browse/QPA-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ