### PR TITLE
Using "providers" term instead of "suppliers"

### DIFF
--- a/services/prometeo/dtos/list-providers-item.dto.ts
+++ b/services/prometeo/dtos/list-providers-item.dto.ts
@@ -1,4 +1,4 @@
-export interface IListSuppliersItemDto {
+export interface IListProvidersItemDto {
   code: string;
   name: string;
   country: string;

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -192,7 +192,11 @@ export const selectClient = api(
     key: Header<"X-Prometeo-Session-Key">;
     // The ID of the client to use for the current session.
     client: string;
-  }): Promise<void> => {
+  }): Promise<{
+    // The session key to be passed to the Prometeo API. This key
+    // might change in certain providers so the previous is invalidated.
+    key: string;
+  }> => {
     const { prometeoService } = await applicationContext;
 
     const clients = await prometeoService.getClients({ key: payload.key });
@@ -211,6 +215,11 @@ export const selectClient = api(
       throw apiError;
     }
 
-    await prometeoService.selectClient(payload.key, payload.client);
+    const result = await prometeoService.selectClient(
+      payload.key,
+      payload.client,
+    );
+
+    return result;
   },
 );

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -8,7 +8,7 @@ import type {
   UserBankAccountMovement,
 } from "./types/user-account";
 import applicationContext from "../applicationContext";
-import type { Supplier } from "./types/supplier";
+import type { Provider } from "./types/provider";
 import {
   validateListUserAccountsPayload,
   validateSelectClientPayload,
@@ -30,14 +30,14 @@ export const login = api(
 
     const { prometeoService } = await applicationContext;
 
-    log.debug("retrieving list of available suppliers to validate the payload");
+    log.debug("retrieving list of available providers to validate the payload");
 
-    const suppliers = await prometeoService.getSuppliers();
-    const supplierNames = suppliers.map((s) => s.name);
+    const providers = await prometeoService.getProviders();
+    const providerNames = providers.map((s) => s.name);
 
     log.debug("validating payload...");
 
-    const apiError = validateLoginPayload(payload, supplierNames);
+    const apiError = validateLoginPayload(payload, providerNames);
     if (apiError) throw apiError;
 
     log.debug("payload is valid, logging in...");
@@ -116,19 +116,19 @@ export const queryUserAccountMovements = api(
 );
 
 // List all the providers that the Prometeo API supports.
-export const listSuppliers = api(
-  { expose: true, method: "GET", path: "/third-party/prometeo/suppliers" },
+export const listProviders = api(
+  { expose: true, method: "GET", path: "/third-party/prometeo/providers" },
   async (): Promise<{
     // An array with all the providers that the Prometeo API supports.
-    data: Supplier[];
+    data: Provider[];
   }> => {
     const { prometeoService } = await applicationContext;
 
-    log.debug("retrieving suppliers...");
+    log.debug("retrieving providers...");
 
-    const data = await prometeoService.getSuppliers();
+    const data = await prometeoService.getProviders();
 
-    log.debug(`${data.length} suppliers retrieved`);
+    log.debug(`${data.length} providers retrieved`);
 
     return { data };
   },

--- a/services/prometeo/prometeo.service.ts
+++ b/services/prometeo/prometeo.service.ts
@@ -619,11 +619,15 @@ export class PrometeoService {
     key: string,
     client: string,
     config?: Partial<PrometeoRequestConfig>,
-  ): Promise<void> {
+  ): Promise<{ key: string }> {
     try {
       const result = await this.doSelectClient(key, client, config);
       if (result.status === "success") {
-        return;
+        return {
+          // If the request returns a new key that is passed, otherwise
+          // the same key used to perform the request is returned.
+          key: result.key ?? key,
+        };
       }
 
       if (result.message === "Invalid key") {
@@ -633,6 +637,10 @@ export class PrometeoService {
       if (result.message === "wrong_client") {
         throw APIError.notFound(`specified client '${client}' does not exist`);
       }
+
+      log.error("something is off with the Prometeo API .:", result);
+
+      throw ServiceError.somethingWentWrong;
     } catch (error) {
       if (error instanceof APIError) throw error;
 

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -135,6 +135,11 @@ export type PrometeoAPISelectClientResponse =
 
 export interface PrometeoAPISelectClientSuccessfulResponse {
   status: "success";
+  // This key is only present in certian providers. It should
+  // be returned to the client to use for future requests, otherwise
+  // the client can keep using the same session key that used to perform
+  // the request.
+  key?: string;
 }
 
 export interface PrometeoAPISelectClientWrongResponse {

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -1,10 +1,15 @@
 import type { UserBankAccount, UserBankAccountMovement } from "./user-account";
 
 export interface PrometeoAPILoginRequestBody {
+  // The provider to login to.
   provider: string;
+  // The "access key ID" to use for the login.
   username: string;
+  // The "access key secret" to use for the login.
   password: string;
+  // Optional. The type of account or document (this will vary depending on the provider).
   type?: string;
+  // Optional. The OTP code to use for the login if the provider required it in a previous call.
   otp?: string;
 }
 

--- a/services/prometeo/types/provider.ts
+++ b/services/prometeo/types/provider.ts
@@ -1,4 +1,4 @@
-interface SupplierAuthField {
+interface ProviderAuthField {
   name: string;
   type: "text" | "password" | "choice";
   interactive: boolean;
@@ -12,27 +12,27 @@ interface SupplierAuthField {
   }[];
 }
 
-interface SupplierBankMetadata {
+interface ProviderBankMetadata {
   code: string;
   name: string;
   logo: string;
 }
 
-interface SupplierAccountType {
+interface ProviderAccountType {
   name: string;
   label_es: string;
   label_en: string;
 }
 
-export interface Supplier {
+export interface Provider {
   name: string;
   aliases: string[];
   country: string;
-  auth_fields: SupplierAuthField[];
+  auth_fields: ProviderAuthField[];
   // endpoints_status?: any;
-  account_type: SupplierAccountType[];
+  account_type: ProviderAccountType[];
   logo: string;
-  bank: SupplierBankMetadata;
+  bank: ProviderBankMetadata;
   methods: {
     accounts: boolean;
     credit_cards: boolean;


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR depends on https://github.com/Qompa-Fi/encore-nestjs-backend/pull/55.

With the goal to improve readibility I've decided to rename all the internal references to just "providers" because is kinda confusing to have mixed "supplied" and "providers" in the code-base.

Bad decision of mine but this will fix it.