### PR TITLE
Using "bank accounts" term instead of "user accounts" 

### DIFF
--- a/services/prometeo/dtos/list-providers-item.dto.ts
+++ b/services/prometeo/dtos/list-providers-item.dto.ts
@@ -1,4 +1,4 @@
-export interface IListSuppliersItemDto {
+export interface IListProvidersItemDto {
   code: string;
   name: string;
   country: string;

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -192,7 +192,11 @@ export const selectClient = api(
     key: Header<"X-Prometeo-Session-Key">;
     // The ID of the client to use for the current session.
     client: string;
-  }): Promise<void> => {
+  }): Promise<{
+    // The session key to be passed to the Prometeo API. This key
+    // might change in certain providers so the previous is invalidated.
+    key: string;
+  }> => {
     const { prometeoService } = await applicationContext;
 
     const clients = await prometeoService.getClients({ key: payload.key });
@@ -211,6 +215,11 @@ export const selectClient = api(
       throw apiError;
     }
 
-    await prometeoService.selectClient(payload.key, payload.client);
+    const result = await prometeoService.selectClient(
+      payload.key,
+      payload.client,
+    );
+
+    return result;
   },
 );

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -10,12 +10,12 @@ import type {
 import applicationContext from "../applicationContext";
 import type { Provider } from "./types/provider";
 import {
-  validateListUserAccountsPayload,
+  validateListBankAccountMovementsPayload,
+  validateListBankAccountsPayload,
   validateSelectClientPayload,
   validateGetClientsPayload,
   validateLoginPayload,
   validateLogoutPayload,
-  validateListUserAccountMovementsPayload,
 } from "./validators/prometeo-api";
 import type { LoginResponse } from "./types/response";
 import { ServiceError } from "./service-errors";
@@ -76,7 +76,7 @@ export const logout = api(
 );
 
 // Endpoint to query movements of a user account in a given currency and date range.
-export const queryUserAccountMovements = api(
+export const queryBankAccountMovements = api(
   {
     expose: true,
     method: "GET",
@@ -99,15 +99,15 @@ export const queryUserAccountMovements = api(
     data: UserBankAccountMovement[];
   }> => {
     log.debug(
-      `retrieving movements from account ${payload.account}(${payload.currency}) from ${payload.date_start} to ${payload.date_end}...`,
+      `retrieving movements from bank account ${payload.account}(${payload.currency}) from ${payload.date_start} to ${payload.date_end}...`,
     );
 
-    const apiError = validateListUserAccountMovementsPayload(payload);
+    const apiError = validateListBankAccountMovementsPayload(payload);
     if (apiError) throw apiError;
 
     const { prometeoService } = await applicationContext;
 
-    const data = await prometeoService.listUserAccountMovements(payload);
+    const data = await prometeoService.listBankAccountMovements(payload);
 
     log.debug(`returning ${data.length} user account movements...`);
 
@@ -155,7 +155,7 @@ export const listClients = api(
 
 // List all the accounts that the specified session key has access to.
 // Those accounts will vary depending on the specified provider and/or client.
-export const listUserAccounts = api(
+export const listBankAccounts = api(
   { expose: true, method: "GET", path: "/third-party/prometeo/accounts" },
   async (payload: {
     // The session key to be passed to the Prometeo API.
@@ -164,12 +164,12 @@ export const listUserAccounts = api(
     // An array containing all the accounts that the specified session key has access to.
     data: UserBankAccount[];
   }> => {
-    const apiError = validateListUserAccountsPayload(payload);
+    const apiError = validateListBankAccountsPayload(payload);
     if (apiError) throw apiError;
 
     const { prometeoService } = await applicationContext;
 
-    const data = await prometeoService.listUserAccounts(payload.key);
+    const data = await prometeoService.listBankAccounts(payload.key);
 
     return { data };
   },

--- a/services/prometeo/prometeo.controller.ts
+++ b/services/prometeo/prometeo.controller.ts
@@ -8,7 +8,7 @@ import type {
   UserBankAccountMovement,
 } from "./types/user-account";
 import applicationContext from "../applicationContext";
-import type { Supplier } from "./types/supplier";
+import type { Provider } from "./types/provider";
 import {
   validateListUserAccountsPayload,
   validateSelectClientPayload,
@@ -30,14 +30,14 @@ export const login = api(
 
     const { prometeoService } = await applicationContext;
 
-    log.debug("retrieving list of available suppliers to validate the payload");
+    log.debug("retrieving list of available providers to validate the payload");
 
-    const suppliers = await prometeoService.getSuppliers();
-    const supplierNames = suppliers.map((s) => s.name);
+    const providers = await prometeoService.getProviders();
+    const providerNames = providers.map((s) => s.name);
 
     log.debug("validating payload...");
 
-    const apiError = validateLoginPayload(payload, supplierNames);
+    const apiError = validateLoginPayload(payload, providerNames);
     if (apiError) throw apiError;
 
     log.debug("payload is valid, logging in...");
@@ -116,19 +116,19 @@ export const queryUserAccountMovements = api(
 );
 
 // List all the providers that the Prometeo API supports.
-export const listSuppliers = api(
-  { expose: true, method: "GET", path: "/third-party/prometeo/suppliers" },
+export const listProviders = api(
+  { expose: true, method: "GET", path: "/third-party/prometeo/providers" },
   async (): Promise<{
     // An array with all the providers that the Prometeo API supports.
-    data: Supplier[];
+    data: Provider[];
   }> => {
     const { prometeoService } = await applicationContext;
 
-    log.debug("retrieving suppliers...");
+    log.debug("retrieving providers...");
 
-    const data = await prometeoService.getSuppliers();
+    const data = await prometeoService.getProviders();
 
-    log.debug(`${data.length} suppliers retrieved`);
+    log.debug(`${data.length} providers retrieved`);
 
     return { data };
   },

--- a/services/prometeo/prometeo.service.ts
+++ b/services/prometeo/prometeo.service.ts
@@ -12,8 +12,8 @@ import type {
 } from "./types/user-account";
 import type { LoginResponse } from "./types/response";
 import type {
-  PrometeoAPISuccessfulListUserAccountsResponse,
-  PrometeoAPIListUserAccountsResponse,
+  PrometeoAPISuccessfulListBankAccountsResponse,
+  PrometeoAPIListBankAccountsResponse,
   PrometeoAPIGetClientsErrorResponse,
   PrometeoAPIErrorLoginResponse,
   PrometeoAPIGetClientsResponse,
@@ -22,8 +22,8 @@ import type {
   PrometeoAPILogoutResponse,
   PrometeoAPILoginResponse,
   PrometeoAPISelectClientResponse,
-  PrometeoAPIListUserAccountMovementsPayload,
-  PrometeoAPIListUserAccountMovementsResponse,
+  PrometeoAPIListBankAccountMovementsPayload,
+  PrometeoAPIListBankAccountMovementsResponse,
 } from "./types/prometeo-api";
 import type { Provider } from "./types/provider";
 import type { Client } from "./types/client";
@@ -380,16 +380,16 @@ export class PrometeoService {
     };
   }
 
-  private async doListUserAccounts(
+  private async doListBankAccounts(
     key: string,
     config?: Partial<PrometeoRequestConfig>,
-  ): Promise<PrometeoAPISuccessfulListUserAccountsResponse> {
+  ): Promise<PrometeoAPISuccessfulListBankAccountsResponse> {
     const { maxBackoff, maxAttempts } = { ...defaultConfig, ...config };
 
     const queryParams = new URLSearchParams({ key });
     const url = `${prometeoApiUrl()}/account/?${queryParams}`;
 
-    const faultTolerantListUserAccounts = async (
+    const faultTolerantListBankAccounts = async (
       retries = 0,
       backoff = 100,
     ) => {
@@ -413,7 +413,7 @@ export class PrometeoService {
 
           const nextBackoff = Math.min(backoff * 2, maxBackoff);
 
-          return await faultTolerantListUserAccounts(retries + 1, nextBackoff);
+          return await faultTolerantListBankAccounts(retries + 1, nextBackoff);
         }
 
         const text = await response.text();
@@ -423,10 +423,10 @@ export class PrometeoService {
 
       const data = await response.json();
 
-      return data as PrometeoAPIListUserAccountsResponse;
+      return data as PrometeoAPIListBankAccountsResponse;
     };
 
-    const result = await faultTolerantListUserAccounts();
+    const result = await faultTolerantListBankAccounts();
     // ! check if the status is "success" as well
 
     if (result.status === "error") {
@@ -442,9 +442,9 @@ export class PrometeoService {
     return result;
   }
 
-  async listUserAccounts(key: string): Promise<UserBankAccount[]> {
+  async listBankAccounts(key: string): Promise<UserBankAccount[]> {
     try {
-      const { accounts } = await this.doListUserAccounts(key);
+      const { accounts } = await this.doListBankAccounts(key);
 
       return accounts;
     } catch (error) {
@@ -650,10 +650,10 @@ export class PrometeoService {
     }
   }
 
-  async doListUserAccountMovements(
-    payload: PrometeoAPIListUserAccountMovementsPayload,
+  async doListBankAccountMovements(
+    payload: PrometeoAPIListBankAccountMovementsPayload,
     config?: Partial<PrometeoRequestConfig>,
-  ): Promise<PrometeoAPIListUserAccountMovementsResponse> {
+  ): Promise<PrometeoAPIListBankAccountMovementsResponse> {
     const { maxBackoff, maxAttempts } = { ...defaultConfig, ...config };
 
     const queryParams = new URLSearchParams({
@@ -666,10 +666,10 @@ export class PrometeoService {
     const url = `${prometeoApiUrl()}/account/${payload.account}/movement/?${queryParams}`;
     const requestInit = this.getPrometeoRequestInit("GET");
 
-    const faultTolerantListUserAccountMovements = async (
+    const faultTolerantListBankAccountMovements = async (
       retries = 0,
       backoff = 100,
-    ): Promise<PrometeoAPIListUserAccountMovementsResponse> => {
+    ): Promise<PrometeoAPIListBankAccountMovementsResponse> => {
       const response = await fetch(url, requestInit);
 
       if (!response.ok) {
@@ -690,7 +690,7 @@ export class PrometeoService {
 
           const nextBackoff = Math.min(backoff * 2, maxBackoff);
 
-          return await faultTolerantListUserAccountMovements(
+          return await faultTolerantListBankAccountMovements(
             retries + 1,
             nextBackoff,
           );
@@ -703,18 +703,18 @@ export class PrometeoService {
 
       const data = await response.json();
 
-      return data as PrometeoAPIListUserAccountMovementsResponse;
+      return data as PrometeoAPIListBankAccountMovementsResponse;
     };
 
-    return await faultTolerantListUserAccountMovements();
+    return await faultTolerantListBankAccountMovements();
   }
 
-  async listUserAccountMovements(
-    payload: PrometeoAPIListUserAccountMovementsPayload,
+  async listBankAccountMovements(
+    payload: PrometeoAPIListBankAccountMovementsPayload,
     config?: PrometeoRequestConfig,
   ): Promise<UserBankAccountMovement[]> {
     try {
-      const result = await this.doListUserAccountMovements(payload, config);
+      const result = await this.doListBankAccountMovements(payload, config);
       if (result.status === "error") {
         if (result.message === "Invalid key") {
           throw ServiceError.sessionKeyInvalidOrExpired;

--- a/services/prometeo/prometeo.service.ts
+++ b/services/prometeo/prometeo.service.ts
@@ -619,11 +619,15 @@ export class PrometeoService {
     key: string,
     client: string,
     config?: Partial<PrometeoRequestConfig>,
-  ): Promise<void> {
+  ): Promise<{ key: string }> {
     try {
       const result = await this.doSelectClient(key, client, config);
       if (result.status === "success") {
-        return;
+        return {
+          // If the request returns a new key that is passed, otherwise
+          // the same key used to perform the request is returned.
+          key: result.key ?? key,
+        };
       }
 
       if (result.message === "Invalid key") {
@@ -633,6 +637,10 @@ export class PrometeoService {
       if (result.message === "wrong_client") {
         throw APIError.notFound(`specified client '${client}' does not exist`);
       }
+
+      log.error("something is off with the Prometeo API .:", result);
+
+      throw ServiceError.somethingWentWrong;
     } catch (error) {
       if (error instanceof APIError) throw error;
 

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -135,6 +135,11 @@ export type PrometeoAPISelectClientResponse =
 
 export interface PrometeoAPISelectClientSuccessfulResponse {
   status: "success";
+  // This key is only present in certian providers. It should
+  // be returned to the client to use for future requests, otherwise
+  // the client can keep using the same session key that used to perform
+  // the request.
+  key?: string;
 }
 
 export interface PrometeoAPISelectClientWrongResponse {

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -95,13 +95,13 @@ export type PrometeoAPILogoutResponse =
   | PrometeoAPISuccessfulLogoutResponse
   | PrometeoAPIErrorLoginResponse;
 
-export interface PrometeoAPISuccessfulListUserAccountsResponse {
+export interface PrometeoAPISuccessfulListBankAccountsResponse {
   status: "success";
   accounts: UserBankAccount[];
 }
 
-export type PrometeoAPIListUserAccountsResponse =
-  | PrometeoAPISuccessfulListUserAccountsResponse
+export type PrometeoAPIListBankAccountsResponse =
+  | PrometeoAPISuccessfulListBankAccountsResponse
   | PrometeoAPIErrorInvalidKeyResponse;
 
 /**
@@ -147,7 +147,7 @@ export interface PrometeoAPISelectClientWrongResponse {
   message: "wrong_client";
 }
 
-export interface PrometeoAPIListUserAccountMovementsPayload {
+export interface PrometeoAPIListBankAccountMovementsPayload {
   key: string;
   account: string;
   currency: string;
@@ -155,11 +155,11 @@ export interface PrometeoAPIListUserAccountMovementsPayload {
   date_end: string;
 }
 
-export type PrometeoAPIListUserAccountMovementsResponse =
-  | PrometeoAPIListUserAccountMovementsSuccessfulResponse
+export type PrometeoAPIListBankAccountMovementsResponse =
+  | PrometeoAPIListBankAccountMovementsSuccessfulResponse
   | PrometeoAPIErrorInvalidKeyResponse;
 
-export interface PrometeoAPIListUserAccountMovementsSuccessfulResponse {
+export interface PrometeoAPIListBankAccountMovementsSuccessfulResponse {
   status: "success";
   movements: UserBankAccountMovement[];
 }

--- a/services/prometeo/types/prometeo-api.ts
+++ b/services/prometeo/types/prometeo-api.ts
@@ -1,10 +1,15 @@
 import type { UserBankAccount, UserBankAccountMovement } from "./user-account";
 
 export interface PrometeoAPILoginRequestBody {
+  // The provider to login to.
   provider: string;
+  // The "access key ID" to use for the login.
   username: string;
+  // The "access key secret" to use for the login.
   password: string;
+  // Optional. The type of account or document (this will vary depending on the provider).
   type?: string;
+  // Optional. The OTP code to use for the login if the provider required it in a previous call.
   otp?: string;
 }
 

--- a/services/prometeo/types/provider.ts
+++ b/services/prometeo/types/provider.ts
@@ -1,4 +1,4 @@
-interface SupplierAuthField {
+interface ProviderAuthField {
   name: string;
   type: "text" | "password" | "choice";
   interactive: boolean;
@@ -12,27 +12,27 @@ interface SupplierAuthField {
   }[];
 }
 
-interface SupplierBankMetadata {
+interface ProviderBankMetadata {
   code: string;
   name: string;
   logo: string;
 }
 
-interface SupplierAccountType {
+interface ProviderAccountType {
   name: string;
   label_es: string;
   label_en: string;
 }
 
-export interface Supplier {
+export interface Provider {
   name: string;
   aliases: string[];
   country: string;
-  auth_fields: SupplierAuthField[];
+  auth_fields: ProviderAuthField[];
   // endpoints_status?: any;
-  account_type: SupplierAccountType[];
+  account_type: ProviderAccountType[];
   logo: string;
-  bank: SupplierBankMetadata;
+  bank: ProviderBankMetadata;
   methods: {
     accounts: boolean;
     credit_cards: boolean;

--- a/services/prometeo/validators/prometeo-api.ts
+++ b/services/prometeo/validators/prometeo-api.ts
@@ -3,7 +3,7 @@ import { isMatch } from "date-fns";
 
 import type {
   PrometeoAPIGetClientsPayload,
-  PrometeoAPIListUserAccountMovementsPayload,
+  PrometeoAPIListBankAccountMovementsPayload,
   PrometeoAPILoginRequestBody,
 } from "../types/prometeo-api";
 
@@ -59,7 +59,7 @@ export const validateLogoutPayload = (payload: { key: string }):
   if (error) return error;
 };
 
-export const validateListUserAccountsPayload = (payload: { key: string }):
+export const validateListBankAccountsPayload = (payload: { key: string }):
   | APIError
   | undefined => {
   const error = checkPrometeoSessionKey(payload.key);
@@ -108,8 +108,8 @@ export const validateSelectClientPayload = (
   }
 };
 
-export const validateListUserAccountMovementsPayload = (
-  payload: PrometeoAPIListUserAccountMovementsPayload,
+export const validateListBankAccountMovementsPayload = (
+  payload: PrometeoAPIListBankAccountMovementsPayload,
 ): APIError | undefined => {
   let error = checkNonEmptyString("currency", payload.currency, 3, 3);
   if (error) return error;


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR depends on https://github.com/Qompa-Fi/encore-nestjs-backend/pull/56.

Well, this is more obvious, in Prometeo API you can either query a bank account of either a company or a person so I think that this term is more appropiated for the case. :)