### PR TITLE
Refactor: using recomended API definition syntax

### DIFF
--- a/services/organizations/types/request.ts
+++ b/services/organizations/types/request.ts
@@ -1,3 +1,12 @@
+import type { TeamSize } from "./team-size";
+
 export interface GetUserOrganizationParams {
   id: number;
+}
+
+export interface CreateOrganizationParams {
+  name: string;
+  category: string;
+  ruc: string;
+  size: TeamSize;
 }

--- a/services/organizations/types/response.ts
+++ b/services/organizations/types/response.ts
@@ -1,5 +1,13 @@
 import type { SerializableOrganization } from "../interfaces/serializable-organization.interface";
 
+export interface GetOrganizationsResponse {
+  organizations: SerializableOrganization[];
+}
+
 export interface GetUserOrganizationResponse {
+  organization: SerializableOrganization;
+}
+
+export interface CreateOrganizationResponse {
   organization: SerializableOrganization;
 }

--- a/services/organizations/validators/request.ts
+++ b/services/organizations/validators/request.ts
@@ -1,15 +1,9 @@
+import type { CreateOrganizationParams } from "../types/request";
+import { TEAM_SIZES } from "../types/team-size";
 import { checkRuc } from "@/lib/sunat";
-import { TEAM_SIZES, type TeamSize } from "../types/team-size";
 
-export interface ICreateOrganizationDto {
-  name: string;
-  category: string;
-  ruc: string;
-  size: TeamSize;
-}
-
-export const checkCreateOrganizationDto = (
-  dto: ICreateOrganizationDto,
+export const checkCreateOrganizationParams = (
+  dto: CreateOrganizationParams,
   validRubroIds: string[],
 ): string | null => {
   const errorMessage = checkRuc(dto.ruc);

--- a/services/sunat/dtos/get-rubros.dto.ts
+++ b/services/sunat/dtos/get-rubros.dto.ts
@@ -1,5 +1,0 @@
-import type { IRubro } from "../interfaces/rubro.interface";
-
-export interface GetRubrosDto {
-  rubros: IRubro[];
-}

--- a/services/sunat/dtos/search-by-dni.dto.ts
+++ b/services/sunat/dtos/search-by-dni.dto.ts
@@ -1,5 +1,0 @@
-import type { IDNI } from "../interfaces/dni.interface";
-
-export interface SearchDNIResponseDto {
-  dni: IDNI;
-}

--- a/services/sunat/dtos/search-by-ruc.dto.ts
+++ b/services/sunat/dtos/search-by-ruc.dto.ts
@@ -1,5 +1,0 @@
-import type { IRUC } from "../interfaces/ruc.interface";
-
-export interface SearchRUCResponseDto {
-  ruc: IRUC;
-}

--- a/services/sunat/dtos/sunat-profile-response.dto.ts
+++ b/services/sunat/dtos/sunat-profile-response.dto.ts
@@ -1,5 +1,0 @@
-import type { SerializableSunatProfile } from "../interfaces/serializable-sunat-profile.interface";
-
-export interface ISunatProfileResponse {
-  sunatProfile: SerializableSunatProfile;
-}

--- a/services/sunat/sunat.service.ts
+++ b/services/sunat/sunat.service.ts
@@ -1,21 +1,19 @@
 import { Injectable, type OnModuleInit } from "@nestjs/common";
 import { PrismaClient, type SunatProfile } from "@prisma/client";
+import { organizations, users } from "~encore/clients";
 import { parse as parseHtml } from "node-html-parser";
 import { secret } from "encore.dev/config";
 import { APIError } from "encore.dev/api";
-import { organizations, users } from "~encore/clients";
 import log from "encore.dev/log";
 import axios from "axios";
 
 import type { LegalRepresentativeDto } from "./interfaces/legal-representative.interface";
-import {
-  type ISaveSunatProfileDto,
-  checkSaveSunatProfileDto,
-} from "./dtos/save-sunat-profile.dto";
+import { checkSaveSunatProfileDto } from "./validators/request";
+import type { SaveSunatProfileParams } from "./types/request";
+import type { IRubro } from "./interfaces/rubro.interface";
 import applicationContext from "../applicationContext";
 import type { IRUC } from "./interfaces/ruc.interface";
 import type { IDNI } from "./interfaces/dni.interface";
-import type { IRubro } from "./interfaces/rubro.interface";
 import { ServiceError } from "./service-errors";
 
 interface EntitySearchParam {
@@ -105,7 +103,7 @@ export class SunatService extends PrismaClient implements OnModuleInit {
   async saveSunatProfile(
     userId: number,
     organizationId: number,
-    payload: ISaveSunatProfileDto,
+    payload: SaveSunatProfileParams,
   ): Promise<SunatProfile> {
     const apiError = checkSaveSunatProfileDto(payload);
     if (apiError) throw apiError;

--- a/services/sunat/types/request.ts
+++ b/services/sunat/types/request.ts
@@ -1,0 +1,12 @@
+export interface SearchByDNIParams {
+  dni: string;
+}
+
+export interface SearchByRUCParams {
+  ruc: string;
+}
+
+export interface SaveSunatProfileParams {
+  solUsername: string;
+  solKey: string;
+}

--- a/services/sunat/types/response.ts
+++ b/services/sunat/types/response.ts
@@ -1,0 +1,22 @@
+import type { SerializableSunatProfile } from "../interfaces/serializable-sunat-profile.interface";
+import type { IRubro } from "../interfaces/rubro.interface";
+import type { IDNI } from "../interfaces/dni.interface";
+import type { IRUC } from "../interfaces/ruc.interface";
+
+export interface SearchByDNIResponse {
+  dni: IDNI;
+}
+
+export interface SearchByRUCResponse {
+  ruc: IRUC;
+}
+
+export interface GetRubrosResponse {
+  rubros: IRubro[];
+}
+
+export interface GetSunatProfileResponse {
+  sunatProfile: SerializableSunatProfile;
+}
+
+export type SaveSunatProfileResponse = GetSunatProfileResponse;

--- a/services/sunat/validators/request.ts
+++ b/services/sunat/validators/request.ts
@@ -1,12 +1,9 @@
 import { APIError } from "encore.dev/api";
 
-export interface ISaveSunatProfileDto {
-  solUsername: string;
-  solKey: string;
-}
+import type { SaveSunatProfileParams } from "../types/request";
 
 export const checkSaveSunatProfileDto = (
-  dto: ISaveSunatProfileDto,
+  dto: SaveSunatProfileParams,
 ): APIError | null => {
   if (!dto.solUsername) {
     return APIError.invalidArgument("solUsername is required");

--- a/services/third-party/truora.controller.ts
+++ b/services/third-party/truora.controller.ts
@@ -16,14 +16,17 @@ import {
 import applicationContext from "../applicationContext";
 import { ServiceError } from "./service-errors";
 
-export const getTruoraProcessResult = api<GetTruoraProcessResultParams>(
+export const getTruoraProcessResult = api<
+  GetTruoraProcessResultParams,
+  GetTruoraProcessResultResponse
+>(
   {
     expose: true,
     method: "GET",
     path: "/third-party/truora/process-result/:process_id",
     auth: true,
   },
-  async (payload): Promise<GetTruoraProcessResultResponse> => {
+  async (payload) => {
     const userId = mayGetInternalUserIdFromAuthData();
     if (!userId) {
       throw ServiceError.somethingWentWrong;
@@ -51,44 +54,46 @@ export const getTruoraProcessResult = api<GetTruoraProcessResultParams>(
 
 // Every registered user must succeed the Truora's identity verification so ensure
 // to claim a key in this endpoint and use it in "https://identity.truora.com".
-export const newTruoraIdentityVerification =
-  api<NewTruoraIdentityVerificationParams>(
-    {
-      expose: true,
-      method: "POST",
-      path: "/third-party/truora/new-identity-verification",
-      auth: true,
-    },
-    async ({ platform }): Promise<NewTruoraIdentityVerificationResponse> => {
-      const user = getAuthData();
-      if (!user) throw ServiceError.somethingWentWrong;
+export const newTruoraIdentityVerification = api<
+  NewTruoraIdentityVerificationParams,
+  NewTruoraIdentityVerificationResponse
+>(
+  {
+    expose: true,
+    method: "POST",
+    path: "/third-party/truora/new-identity-verification",
+    auth: true,
+  },
+  async ({ platform }) => {
+    const user = getAuthData();
+    if (!user) throw ServiceError.somethingWentWrong;
 
-      const userId = mustGetUserIdFromPublicMetadata(user);
+    const userId = mustGetUserIdFromPublicMetadata(user);
 
-      const { truoraService } = await applicationContext;
+    const { truoraService } = await applicationContext;
 
-      const emails =
-        user.metadata.emailAddresses.length > 0
-          ? user.metadata.emailAddresses.map((em) => em.emailAddress)
-          : undefined;
+    const emails =
+      user.metadata.emailAddresses.length > 0
+        ? user.metadata.emailAddresses.map((em) => em.emailAddress)
+        : undefined;
 
-      // const phones =
-      //   user.metadata.phoneNumbers.length > 0
-      //     ? user.metadata.phoneNumbers.map((ph) => ph.phoneNumber)
-      //     : undefined;
+    // const phones =
+    //   user.metadata.phoneNumbers.length > 0
+    //     ? user.metadata.phoneNumbers.map((ph) => ph.phoneNumber)
+    //     : undefined;
 
-      const { api_key } = await truoraService.createApiKey({
-        key_type: platform === "mobile" ? "sdk" : "web",
-        key_name: "qompa-flow",
-        country: "ALL",
-        grant: "digital-identity",
-        flow_id: "IPFe2cb9113707a664e446fe3fb9e52b631",
-        redirect_url: "https://qompa.io",
-        account_id: userId.toString(),
-        emails,
-        // phones,
-      });
+    const { api_key } = await truoraService.createApiKey({
+      key_type: platform === "mobile" ? "sdk" : "web",
+      key_name: "qompa-flow",
+      country: "ALL",
+      grant: "digital-identity",
+      flow_id: "IPFe2cb9113707a664e446fe3fb9e52b631",
+      redirect_url: "https://qompa.io",
+      account_id: userId.toString(),
+      emails,
+      // phones,
+    });
 
-      return { key: api_key };
-    },
-  );
+    return { key: api_key };
+  },
+);

--- a/services/users/types/request.ts
+++ b/services/users/types/request.ts
@@ -1,0 +1,7 @@
+export interface CreateUserParams {
+  acceptTermsAndPrivacyPolicy: boolean;
+}
+
+export interface ExistsByIDParams {
+  id: number;
+}

--- a/services/users/types/response.ts
+++ b/services/users/types/response.ts
@@ -1,0 +1,11 @@
+import type { SerializableUser } from "../interfaces/serializable-user.interface";
+
+export interface GetUserResponse {
+  user: SerializableUser;
+}
+
+export type CreateUserResponse = GetUserResponse;
+
+export interface ExistsByIDResponse {
+  userExists: boolean;
+}

--- a/services/users/users.controller.ts
+++ b/services/users/users.controller.ts
@@ -1,18 +1,19 @@
 import { api, APIError } from "encore.dev/api";
 import log from "encore.dev/log";
 
+import type { CreateUserParams, ExistsByIDParams } from "./types/request";
+import type {
+  CreateUserResponse,
+  ExistsByIDResponse,
+  GetUserResponse,
+} from "./types/response";
 import applicationContext from "@/services/applicationContext";
-import type { SerializableUser } from "./interfaces/serializable-user.interface";
 import { toSerializableUser } from "./helpers/serializable";
 import { mustGetAuthData } from "@/lib/clerk";
 
-interface Response {
-  user: SerializableUser;
-}
-
-export const getUser = api(
+export const getUser = api<void, GetUserResponse>(
   { expose: true, method: "GET", path: "/user", auth: true },
-  async (): Promise<Response> => {
+  async () => {
     const { usersService } = await applicationContext;
     const authenticatedUser = mustGetAuthData();
 
@@ -25,11 +26,9 @@ export const getUser = api(
   },
 );
 
-export const createUser = api(
+export const createUser = api<CreateUserParams, CreateUserResponse>(
   { expose: true, method: "POST", path: "/user", auth: true },
-  async (payload: {
-    acceptTermsAndPrivacyPolicy: boolean;
-  }): Promise<Response> => {
+  async (payload) => {
     const { usersService } = await applicationContext;
     const authenticatedUser = mustGetAuthData();
 
@@ -59,16 +58,12 @@ export const createUser = api(
   },
 );
 
-export const existsById = api(
+export const existsById = api<ExistsByIDParams, ExistsByIDResponse>(
   { expose: false },
-  async ({
-    id,
-  }: { id: number }): Promise<{
-    userExists: boolean;
-  }> => {
+  async (payload) => {
     const { usersService } = await applicationContext;
 
-    const userExists = await usersService.existsById(id);
+    const userExists = await usersService.existsById(payload.id);
 
     return {
       userExists,


### PR DESCRIPTION
## 📔 Objective

This to fix the current client code generation problem that Encore has when trying to use to old syntax that we we're using before to define our API services. Without these changes, calling other micro-services would be hard and I will always need explicit type definitions if you're internally calling them.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- --Used internationalization (i18n) for all UI strings--
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes