### PR TITLE
Users: removed `onboardedAt` field from user entity in order to start managing it from Clerk user

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,6 @@ enum DocumentType {
 model User {
   id                  Int                   @id @default(autoincrement())
   clerkId             String                @unique @map("clerk_id")
-  onboardedAt         DateTime?             @map("onboarded_at")
   documentNumber      String?               @unique @map("document_number")
   documentType        DocumentType?         @map("document_type")
   sunatProfile        SunatProfile?         @relation(fields: [sunatProfileId], references: [id])

--- a/services/users/dtos/update-user.dto.ts
+++ b/services/users/dtos/update-user.dto.ts
@@ -1,5 +1,0 @@
-export interface IUpdateUserDto {
-  acceptTermsAndPrivacyPolicy: boolean;
-  acknowledgesLegalRepresentation: boolean;
-  onboardedAt?: Date;
-}

--- a/services/users/helpers/serializable.ts
+++ b/services/users/helpers/serializable.ts
@@ -13,7 +13,6 @@ export const toSerializableUser = (user: UserModel): SerializableUser => {
   return {
     id: user.id,
     clerk_id: user.clerkId,
-    onboarded_at: user.onboardedAt?.toISOString(),
     document,
   };
 };

--- a/services/users/interfaces/serializable-user.interface.ts
+++ b/services/users/interfaces/serializable-user.interface.ts
@@ -3,7 +3,6 @@ import type { DocumentType } from "../types/user";
 export interface SerializableUser {
   id: number;
   clerk_id: string;
-  onboarded_at?: string;
   document: {
     type: DocumentType;
     number: string;


### PR DESCRIPTION
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- --Used internationalization (i18n) for all UI strings--
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes